### PR TITLE
decorating EXTERNAL_MOVEMENTS_RECORD_INSERTED Event to reduce api cal…

### DIFF
--- a/src/main/java/uk/gov/justice/digital/nomis/jpa/entity/Offender.java
+++ b/src/main/java/uk/gov/justice/digital/nomis/jpa/entity/Offender.java
@@ -1,6 +1,9 @@
 package uk.gov.justice.digital.nomis.jpa.entity;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
 
 import javax.persistence.*;
@@ -9,6 +12,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 @Table(name = "OFFENDERS")
 public class Offender {

--- a/src/main/java/uk/gov/justice/digital/nomis/jpa/entity/OffenderExternalMovement.java
+++ b/src/main/java/uk/gov/justice/digital/nomis/jpa/entity/OffenderExternalMovement.java
@@ -1,6 +1,9 @@
 package uk.gov.justice.digital.nomis.jpa.entity;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -15,12 +18,18 @@ import java.io.Serializable;
 import java.sql.Timestamp;
 
 @Data
+@Builder
 @Entity
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "OFFENDER_EXTERNAL_MOVEMENTS")
 public class OffenderExternalMovement {
 
     @Embeddable
     @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Pk implements Serializable {
         @ManyToOne
         @JoinColumn(name = "OFFENDER_BOOK_ID")
@@ -33,6 +42,10 @@ public class OffenderExternalMovement {
     @EmbeddedId
     private Pk id;
 
+    @Column(name = "MOVEMENT_SEQ", insertable = false, updatable = false)
+    private Long movementSeq;
+    @Column(name = "OFFENDER_BOOK_ID", insertable = false, updatable = false)
+    private Long offenderBookId;
     @Column(name = "MOVEMENT_DATE")
     private Timestamp movementDate;
     @Column(name = "MOVEMENT_TIME")

--- a/src/main/java/uk/gov/justice/digital/nomis/jpa/repository/OffenderExternalMovementsRepository.java
+++ b/src/main/java/uk/gov/justice/digital/nomis/jpa/repository/OffenderExternalMovementsRepository.java
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.nomis.jpa.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import uk.gov.justice.digital.nomis.jpa.entity.OffenderExternalMovement;
+
+import java.util.Optional;
+
+@Repository
+public interface OffenderExternalMovementsRepository extends JpaRepository<OffenderExternalMovement, Long> {
+
+    Optional<OffenderExternalMovement> findByOffenderBookIdAndMovementSeq(Long movementSeq, Long bookingId);
+
+}

--- a/src/main/java/uk/gov/justice/digital/nomis/service/OffenderService.java
+++ b/src/main/java/uk/gov/justice/digital/nomis/service/OffenderService.java
@@ -9,9 +9,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.justice.digital.nomis.api.Offender;
 import uk.gov.justice.digital.nomis.api.OffenderActiveBooking;
+import uk.gov.justice.digital.nomis.jpa.entity.OffenderExternalMovement;
 import uk.gov.justice.digital.nomis.jpa.filters.OffenderBookingFilter;
 import uk.gov.justice.digital.nomis.jpa.repository.AgencyLocationsRepository;
 import uk.gov.justice.digital.nomis.jpa.repository.OffenderBookingRepository;
+import uk.gov.justice.digital.nomis.jpa.repository.OffenderExternalMovementsRepository;
 import uk.gov.justice.digital.nomis.jpa.repository.OffenderRepository;
 import uk.gov.justice.digital.nomis.service.transformer.OffenderActiveBookingTransformer;
 import uk.gov.justice.digital.nomis.service.transformer.OffenderTransformer;
@@ -28,14 +30,16 @@ public class OffenderService {
     private final OffenderRepository offenderRepository;
     private final AgencyLocationsRepository agencyLocationRepository;
     private final OffenderBookingRepository offenderBookingRepository;
+    private final OffenderExternalMovementsRepository offenderExtMovementRepository;
     private final OffenderTransformer offenderTransformer;
     private final OffenderActiveBookingTransformer offenderActiveBookingTransformer;
 
     @Autowired
-    public OffenderService(final OffenderRepository offenderRepository, final AgencyLocationsRepository agencyLocationRepository, final OffenderBookingRepository offenderBookingRepository, final OffenderTransformer offenderTransformer, final OffenderActiveBookingTransformer offenderActiveBookingTransformer) {
+    public OffenderService(final OffenderRepository offenderRepository, final AgencyLocationsRepository agencyLocationRepository, final OffenderBookingRepository offenderBookingRepository, OffenderExternalMovementsRepository offenderExtMovementRepository, final OffenderTransformer offenderTransformer, final OffenderActiveBookingTransformer offenderActiveBookingTransformer) {
         this.offenderRepository = offenderRepository;
         this.agencyLocationRepository = agencyLocationRepository;
         this.offenderBookingRepository = offenderBookingRepository;
+        this.offenderExtMovementRepository = offenderExtMovementRepository;
         this.offenderTransformer = offenderTransformer;
         this.offenderActiveBookingTransformer = offenderActiveBookingTransformer;
     }
@@ -86,5 +90,9 @@ public class OffenderService {
                 .collect(Collectors.toList());
 
         return new PageImpl<>(offenderList, pageable, rootOffendersRawPage.getTotalElements());
+    }
+
+    public Optional<OffenderExternalMovement> getExternalMovement(final Long bookingId, final Long movementSeq) {
+        return offenderExtMovementRepository.findByOffenderBookIdAndMovementSeq(bookingId, movementSeq);
     }
 }

--- a/src/main/java/uk/gov/justice/digital/nomis/service/XtagEventsService.java
+++ b/src/main/java/uk/gov/justice/digital/nomis/service/XtagEventsService.java
@@ -61,6 +61,17 @@ public class XtagEventsService {
                     .orElse(null);
             oe.setOffenderIdDisplay(nomsId);
         }
+        else if ("EXTERNAL_MOVEMENT_RECORD-INSERTED".equals(oe.getEventType())){
+            offenderService.getExternalMovement(oe.getBookingId(), oe.getMovementSeq()).ifPresent(em -> {
+                final var offenderBooking = em.getId().getOffenderBooking();
+                oe.setOffenderIdDisplay(offenderBooking.getOffender().getOffenderIdDisplay());
+                oe.setFromAgencyLocationId(em.getFromAgyLocId());
+                oe.setToAgencyLocationId(em.getToAgyLocId());
+                oe.setDirectionCode(em.getDirectionCode());
+                oe.setMovementDateTime(em.getMovementTime() != null ? em.getMovementTime().toLocalDateTime() : null);
+                oe.setMovementType(em.getMovementReason() != null ? em.getMovementReason().getMovementType() : null);
+            });
+        }
         return oe;
     }
 }

--- a/src/test/java/uk/gov/justice/digital/nomis/service/XtagEventsServiceTest.java
+++ b/src/test/java/uk/gov/justice/digital/nomis/service/XtagEventsServiceTest.java
@@ -9,11 +9,15 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.justice.digital.nomis.api.Offender;
 import uk.gov.justice.digital.nomis.api.OffenderEvent;
+import uk.gov.justice.digital.nomis.jpa.entity.MovementReason;
+import uk.gov.justice.digital.nomis.jpa.entity.OffenderBooking;
+import uk.gov.justice.digital.nomis.jpa.entity.OffenderExternalMovement;
 import uk.gov.justice.digital.nomis.jpa.entity.XtagEventNonJpa;
 import uk.gov.justice.digital.nomis.jpa.filters.OffenderEventsFilter;
 import uk.gov.justice.digital.nomis.jpa.repository.XtagEventsRepository;
 import uk.gov.justice.digital.nomis.service.transformer.OffenderEventsTransformer;
 
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -23,6 +27,8 @@ import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class XtagEventsServiceTest {
+
+    private final Timestamp MOVEMENT_TIME = Timestamp.valueOf("2019-07-12 21:00:00.000");
 
     @Mock
     private XtagEventsRepository repository;
@@ -53,6 +59,79 @@ public class XtagEventsServiceTest {
         final var offenderEventList = service.findAll(filter);
 
         assertThat(offenderEventList).extracting("offenderIdDisplay").containsExactly("A2345GB");
+    }
+
+    @Test
+    public void shouldDecorateWithExternalMovementData() {
+        final var filter = OffenderEventsFilter.builder().from(LocalDateTime.now()).to(LocalDateTime.now()).build();
+        final var offender = uk.gov.justice.digital.nomis.jpa.entity.Offender.builder().offenderIdDisplay("A2345GB").build();
+        final var pk = OffenderExternalMovement.Pk.builder().movementSeq(2L).offenderBooking(OffenderBooking.builder().offender(offender).build()).build();
+        final var externalMovementEntity = OffenderExternalMovement.builder()
+                .fromAgyLocId("MDI")
+                .toAgyLocId("BAI")
+                .movementReason(MovementReason.builder().movementType("REL").build())
+                .movementTime(MOVEMENT_TIME)
+                .id(pk).build();
+
+        final var xTagEvent = XtagEventNonJpa.builder().build();
+        when(repository.findAll(Mockito.any(OffenderEventsFilter.class))).thenReturn(List.of(xTagEvent));
+        when(offenderService.getExternalMovement(1L, 2L)).thenReturn(Optional.of(externalMovementEntity));
+        when(transformer.offenderEventOf(Mockito.any(XtagEventNonJpa.class))).thenReturn(
+                OffenderEvent.builder().eventType("EXTERNAL_MOVEMENT_RECORD-INSERTED").offenderId(1L).movementSeq(2L).bookingId(1L).build());
+
+        final var offenderEventList = service.findAll(filter);
+
+        assertThat(offenderEventList).extracting("offenderIdDisplay").containsExactly("A2345GB");
+        assertThat(offenderEventList).extracting("fromAgencyLocationId").containsExactly("MDI");
+        assertThat(offenderEventList).extracting("toAgencyLocationId").containsExactly("BAI");
+        assertThat(offenderEventList).extracting("movementDateTime").containsExactly(MOVEMENT_TIME.toLocalDateTime());
+        assertThat(offenderEventList).extracting("movementType").containsExactly("REL");
+    }
+
+    @Test
+    public void shouldDecorateWithExternalMovementDataHandlesNullableFields() {
+        final var filter = OffenderEventsFilter.builder().from(LocalDateTime.now()).to(LocalDateTime.now()).build();
+
+        final var offender = uk.gov.justice.digital.nomis.jpa.entity.Offender.builder().offenderIdDisplay("A2345GB").build();
+        final var pk = OffenderExternalMovement.Pk.builder().movementSeq(2L).offenderBooking(OffenderBooking.builder().offender(offender).build()).build();
+        final var externalMovementEntity = OffenderExternalMovement.builder().id(pk).build();
+
+        final var xTagEvent = XtagEventNonJpa.builder().build();
+        when(repository.findAll(Mockito.any(OffenderEventsFilter.class))).thenReturn(List.of(xTagEvent));
+        when(offenderService.getExternalMovement(1L, 2L)).thenReturn(Optional.of(externalMovementEntity));
+        when(transformer.offenderEventOf(Mockito.any(XtagEventNonJpa.class))).thenReturn(
+                OffenderEvent.builder().eventType("EXTERNAL_MOVEMENT_RECORD-INSERTED").offenderId(1L).movementSeq(2L).bookingId(1L).build());
+
+        final var offenderEventList = service.findAll(filter);
+
+        assertThat(offenderEventList).extracting("bookingId").containsExactly(1L);
+        assertThat(offenderEventList).extracting("movementSeq").containsExactly(2L);
+        assertThat(offenderEventList).extracting("offenderIdDisplay").containsExactly("A2345GB");
+        assertThat(offenderEventList).extracting("fromAgencyLocationId").containsNull();
+        assertThat(offenderEventList).extracting("toAgencyLocationId").containsNull();
+        assertThat(offenderEventList).extracting("movementDateTime").containsNull();
+        assertThat(offenderEventList).extracting("movementType").containsNull();
+    }
+
+    @Test
+    public void shouldDecorateWithExternalMovementDataHandlesNoRecordFound() {
+        final var filter = OffenderEventsFilter.builder().from(LocalDateTime.now()).to(LocalDateTime.now()).build();
+
+        final var xTagEvent = XtagEventNonJpa.builder().build();
+        when(repository.findAll(Mockito.any(OffenderEventsFilter.class))).thenReturn(List.of(xTagEvent));
+        when(offenderService.getExternalMovement(1L, 2L)).thenReturn(Optional.empty());
+        when(transformer.offenderEventOf(Mockito.any(XtagEventNonJpa.class))).thenReturn(
+                OffenderEvent.builder().eventType("EXTERNAL_MOVEMENT_RECORD-INSERTED").offenderId(1L).movementSeq(2L).bookingId(1L).build());
+
+        final var offenderEventList = service.findAll(filter);
+
+        assertThat(offenderEventList).extracting("bookingId").containsExactly(1L);
+        assertThat(offenderEventList).extracting("movementSeq").containsExactly(2L);
+        assertThat(offenderEventList).extracting("offenderIdDisplay").containsNull();
+        assertThat(offenderEventList).extracting("fromAgencyLocationId").containsNull();
+        assertThat(offenderEventList).extracting("toAgencyLocationId").containsNull();
+        assertThat(offenderEventList).extracting("movementDateTime").containsNull();
+        assertThat(offenderEventList).extracting("movementType").containsNull();
     }
 
     @Test


### PR DESCRIPTION
…ls on the consumer side.

Example event:
{
        "eventType": "EXTERNAL_MOVEMENT_RECORD-INSERTED",
        "eventDatetime": "2020-02-25T16:02:52.818486",
        "offenderIdDisplay": "A5122DY",
        "bookingId": 1200869,
        "movementSeq": 1,
        "movementDateTime": "2020-02-25T15:57:45",
        "movementType": "ADM",
        "directionCode": "IN",
        "fromAgencyLocationId": "ALTRCT",
        "toAgencyLocationId": "MDI",
        "nomisEventType": "M1_RESULT"
    }