### PR TITLE
DT-465 Convert S2_RESULTS to new event to avoid duplicate SENTENCE_CA…

### DIFF
--- a/src/main/java/uk/gov/justice/digital/nomis/service/transformer/OffenderEventsTransformer.java
+++ b/src/main/java/uk/gov/justice/digital/nomis/service/transformer/OffenderEventsTransformer.java
@@ -242,7 +242,7 @@ public class OffenderEventsTransformer {
                 case "OFF_PROF_DETAIL_UPD":
                     return offenderProfileUpdatedEventOf(xtag);
                 case "S2_RESULT":
-                    return sentenceCaclulationDateChangedEventOf(xtag);
+                    return sentenceDatesChangedEventOf(xtag);
                 case "A2_CALLBACK":
                     return hearingDateChangedEventOf(xtag);
                 case "A2_RESULT":
@@ -284,7 +284,7 @@ public class OffenderEventsTransformer {
                 case "S1_DEL_RESULT":
                     return alertDeletedEventOf(xtag);
                 case "OFF_SENT_OASYS":
-                    return sentenceCaclulationDateChangedEventOf(xtag);
+                    return sentenceCalculationDateChangedEventOf(xtag);
                 case "C_NOTIFICATION":
                     return courtSentenceChangedEventOf(xtag);
                 case "IEDT_OUT":
@@ -554,9 +554,18 @@ public class OffenderEventsTransformer {
                 .build();
     }
 
-    private OffenderEvent sentenceCaclulationDateChangedEventOf(final Xtag xtag) {
+    private OffenderEvent sentenceCalculationDateChangedEventOf(final Xtag xtag) {
         return OffenderEvent.builder()
                 .eventType("SENTENCE_CALCULATION_DATES-CHANGED")
+                .eventDatetime(xtag.getNomisTimestamp())
+                .bookingId(longOf(xtag.getContent().getP_offender_book_id()))
+                .nomisEventType(xtag.getEventType())
+                .build();
+    }
+
+    private OffenderEvent sentenceDatesChangedEventOf(final Xtag xtag) {
+        return OffenderEvent.builder()
+                .eventType("SENTENCE_DATES-CHANGED")
                 .eventDatetime(xtag.getNomisTimestamp())
                 .bookingId(longOf(xtag.getContent().getP_offender_book_id()))
                 .sentenceCalculationId(longOf(xtag.getContent().getP_offender_sent_calculation_id()))


### PR DESCRIPTION
The problem:

- Two SENTENCE_CALCULATION_DATES-CHANGED are currently being translated for S2_RESULT and OFF_SENT_OASYS and sent
- NDH to  OAsys only looks at the OFF_SENT_OASYS version by subscribing to SENTENCE_CALCULATION_DATES-CHANGED but then inspecting the original event type; OFF_SENT_OASYS
- S2_RESULT is sent as result of any date change where as OFF_SENT_OASYS is only sent for a subset
- Therefore to avoid breaking NDH S2_RESULT  is now translated to new  SENTENCE_
DATES-CHANGED event